### PR TITLE
Added python-lxml

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -148,7 +148,7 @@ Description: ArcheOS DB metapackage
 
 Package: archeos-graphics
 Architecture: all
-Depends: darktable, gimp, gimp-lensfun, gimp-plugin-registry, geeqie, imagej, inkscape, shutter, ${misc:Depends}
+Depends: darktable, gimp, gimp-lensfun, gimp-plugin-registry, geeqie, imagej, inkscape, shutter, python-lxml, ${misc:Depends}
 Description: ArcheOS Graphics metapackage
  This package depends on all of the packages in the ArcheOS Graphics section.
  .


### PR DESCRIPTION
In order to export optimized svg from Inkscape (to be used for js library Raphael), the library python-lxml has been added